### PR TITLE
sed command wasn't properly removing color escapes

### DIFF
--- a/sack
+++ b/sack
@@ -138,10 +138,10 @@ remove_escaped_chars() {
 
     # Linux
     if [[ $sack__OS == "Linux" ]]; then
-        sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" 
+        sed -r "s/\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"
     # OS X
     elif [[ $sack__OS == "Darwin" ]]; then
-        sed -E "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" 
+        sed -E "s/\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"
     fi
     # @todo: implement support for other OSes at a later date
 }


### PR DESCRIPTION
Previously, sack wasn't correctly sanitizing the colored results from
ack or ag. This patch changes the sed command used to sanitize the
colored results from using the hex representation of an escape, \x1B, to
using an escape literal, . This corrects the problem.