### PR TITLE
Enable shortcut command to use $EDITOR

### DIFF
--- a/sack
+++ b/sack
@@ -151,9 +151,16 @@ create_shortcut_cmd() {
     # @todo: add support for other editors as well
     # The following literally writes the shorcut command and makes it executable
     sack__shortcut_cmd_path=~/bin/$sack__shortcut_cmd
-    echo "#!/bin/bash" > $sack__shortcut_cmd_path
-    echo "sack__vim_shortcut=\$(sed -n \"\$1p\" < $sack__shortcut_file)" >> $sack__shortcut_cmd_path
-    echo "$sack__default_editor +\$sack__vim_shortcut" >> $sack__shortcut_cmd_path
+    cat > $sack__shortcut_cmd_path <<SHORTCUT
+#!/bin/bash
+sack__vim_shortcut=\$(sed -n "\$1p" < $sack__shortcut_file)
+if [ -z "\$EDITOR" ]; then
+    sack__editor="$sack__default_editor"
+else
+    sack__editor="\$EDITOR"
+fi
+\$sack__editor +\$sack__vim_shortcut
+SHORTCUT
     chmod +x $sack__shortcut_cmd_path
 }
 


### PR DESCRIPTION
`create_shortcut_cmd()` now checks to see if `$EDITOR` is set, and if so
uses that value instead of `$sack__default_editor`.  Also, I used a
heredoc rather than repeated echo statements to populate the shortcut
command because it made editing the command's content much easier.