### PR TITLE
Don't overwrite existing .sackrc in install script

### DIFF
--- a/install_sack.sh
+++ b/install_sack.sh
@@ -25,4 +25,19 @@ cp $sack__install_cwd/sack $sack__install_main/
 chmod +x $sack__install_main/sack
 cp $sack__install_cwd/sag $sack__install_main/
 chmod +x $sack__install_main/sag
-cp $sack__install_cwd/.sackrc $sack__install_sackrc/
+
+if [[ -f "$sack__install_sackrc/.sackrc" ]]; then
+    echo >&2
+    echo "It seems you already have a ~/.sackrc." >&2
+    echo >&2
+    echo "Overwrite this with a fresh copy from the source distribution" >&2
+    echo "(losing your customizations)?" >&2
+    echo >&2
+    read -p "(Ctrl+C to quit) y/[N]? " ANS
+    if [[ $ANS =~ ^[Yy] ]]; then
+        cp $sack__install_cwd/.sackrc $sack__install_sackrc/
+    else
+        echo
+        echo "Okay, not overwriting your existing ~/.sackrc."
+    fi
+fi


### PR DESCRIPTION
Hi, Sampson.

Here's a small modification to `install_sack.sh` that doesn't overwrite my existing `.sackrc` configuration file.

I received quite a surprise when I did a `git pull` and ran the install script to install the new versions. My fault for not carefully reading the install script, I guess, but let's prevent that from happening to other people in the future, shall we?

Have a great rest of your week.