### PR TITLE
Fix install_sack.sh so it creates a .sackrc again if it doesn’t exist

### DIFF
--- a/install_sack.sh
+++ b/install_sack.sh
@@ -24,7 +24,18 @@ fi
 
 # If ack is not installed, install it
 if [[ `which ack | wc -l` -eq 0 ]]; then
-    curl -L http://betterthangrep.com/ack-standalone > $sack__install_main/ack && chmod 0755 $sack__install_main/ack
+    echo "Downloading 'ack' to '$sack__install_main/ack'..."
+    # FIXME: https
+    curl -s -L http://betterthangrep.com/ack-standalone \
+        > $sack__install_main/ack && chmod 0755 $sack__install_main/ack
+
+    if (( $? )); then
+        echo
+        echo "ACK! There was a problem downloading 'ack' from betterthangrep.com" >&2
+        echo "     Bailing out." >&2
+        echo
+        exit 1
+    fi
 fi
 
 # No install script for ag, so let it be a TODO

--- a/install_sack.sh
+++ b/install_sack.sh
@@ -12,13 +12,14 @@
 # run this script from where the git repo is cloned to.
 
 # sack installation variables
-sack__install_main=~/bin
-sack__install_sackrc=~/
+sack__install_main=$HOME/bin
+sack__install_sackrc=$HOME
 sack__install_cwd=$(pwd)
 
 # If the install directory doesn't exist, create it
 if [[ ! -d "$sack__install_main" ]]; then
-    mkdir $sack__install_main
+    echo "Creating '$sack__install_main'..."
+    mkdir "$sack__install_main"
 fi
 
 # If ack is not installed, install it
@@ -28,23 +29,34 @@ fi
 
 # No install script for ag, so let it be a TODO
 
-cp $sack__install_cwd/sack $sack__install_main/
-chmod +x $sack__install_main/sack
-cp $sack__install_cwd/sag $sack__install_main/
-chmod +x $sack__install_main/sag
+echo "Copying 'sack' to '$sack__install_main/sack'..."
+cp "$sack__install_cwd/sack" "$sack__install_main"
+chmod +x "$sack__install_main/sack"
+
+echo "Copying 'sag' to '$sack__install_main/sag'..."
+cp "$sack__install_cwd/sag" "$sack__install_main"
+chmod +x "$sack__install_main/sag"
 
 if [[ -f "$sack__install_sackrc/.sackrc" ]]; then
     echo >&2
-    echo "It seems you already have a ~/.sackrc." >&2
+    echo "It seems you already have a .sackrc from a previous install." >&2
     echo >&2
     echo "Overwrite this with a fresh copy from the source distribution" >&2
     echo "(losing your customizations)?" >&2
     echo >&2
     read -p "(Ctrl+C to quit) y/[N]? " ANS
     if [[ $ANS =~ ^[Yy] ]]; then
-        cp $sack__install_cwd/.sackrc $sack__install_sackrc/
+        echo
+        echo "Overwriting your existing rcfile at '$sack__install_main/.sackrc'..."
+        cp "$sack__install_cwd/.sackrc" "$sack__install_sackrc"
     else
         echo
-        echo "Okay, not overwriting your existing ~/.sackrc."
+        echo "Okay, not overwriting your existing .sackrc."
     fi
+else
+    echo "Creating new rcfile at '$sack__install_main/.sackrc'..."
+    cp "$sack__install_cwd/.sackrc" "$sack__install_sackrc"
 fi
+
+echo
+echo "All done."


### PR DESCRIPTION
Should repair the damage I did to `install_sack.sh` with c60e48ae5ce4754dbb52e14814155fd20408dec9. My apologies.

Also, handle a failure while downloading `ack` from beyondgrep.com and abort the script, although this might not make people happy who would rather just use `ag`. Please let me know if I should just warn instead and I’ll redo the pull request.