### PR TITLE
update sack script to work on Cygwin

### DIFF
--- a/sack
+++ b/sack
@@ -136,8 +136,8 @@ remove_escaped_chars() {
     # Need to do a check for the OS, because Linux uses a different sed
     # than OS X
 
-    # Linux
-    if [[ $sack__OS == "Linux" ]]; then
+    # Linux / Cygwin
+    if [[ $sack__OS == "Linux" ]] || [[ $sack__OS == "$CYGWIN_NT"* ]]; then
         sed -r "s/\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"
     # OS X
     elif [[ $sack__OS == "Darwin" ]]; then


### PR DESCRIPTION
Hi - just found your tool today, very useful! I had to make a tweak to get it working on Cygwin. Prior to this change, the ~/.sack_shortcuts file was empty, so the "F 1" "F 2" etc. commands didn't work.