### PR TITLE
update vim shortcut command to work when shortcuts file has no line n…

### DIFF
--- a/sack
+++ b/sack
@@ -154,14 +154,21 @@ create_shortcut_cmd_vim() {
     cat > $sack__shortcut_cmd_path <<SHORTCUT
 #!/bin/bash
 sack__vim_shortcut=\$(sed -n "\$1p" < $sack__shortcut_file)
-sack__line=\`echo \$sack__vim_shortcut | cut -d" " -f1\`
-sack__file=\`echo \$sack__vim_shortcut | sed 's/'\$sack__line' //'\`
 if [ -z "\$EDITOR" ]; then
     sack__editor="$sack__default_editor"
 else
     sack__editor="\$EDITOR"
 fi
-\$sack__editor +\$sack__line "\$sack__file"
+num_fields=\`head -n 1 $sack__shortcut_file | awk '{ print NF }'\`
+if [ \${num_fields} -eq 2 ]; then
+	sack__line=\`echo \$sack__vim_shortcut | cut -d" " -f1\`
+	sack__file=\`echo \$sack__vim_shortcut | sed 's/'\$sack__line' //'\`
+	\$sack__editor +\$sack__line "\$sack__file"
+else
+	# trim whitespace from filename
+	sack__file=\`echo \$sack__vim_shortcut | awk '{print \$1}'\`
+	\$sack__editor "\$sack__file"
+fi
 SHORTCUT
     chmod +x $sack__shortcut_cmd_path
 }


### PR DESCRIPTION
I often use grep/ack/ag with the "-l" switch to just list relevant files without listing exact line number matches. sack/sag displays good output with this switch, but the generated ~/.sack_shortcuts file causes problems in the create_shortcut_vim_cmd function. This change updates that function to check to see if line numbers are present in ~/.sack_shortcuts. If they are, it functions as before. If not, it launches Vim without a line number.

I didn't test this functionality with other editors, this just affects Vim users.