### PR TITLE
Make sack compatible as zsh plugins

### DIFF
--- a/sack.plugin.zsh
+++ b/sack.plugin.zsh
@@ -1,0 +1,11 @@
+sack__install_sackrc=$HOME
+sack__install_cwd=${0:h}
+
+# Add sack helpers to binary path
+export PATH="$sack__install_cwd:$PATH"
+
+# Create .sackrc if it does not yet exist.
+if [[ ! -f "$sack__install_sackrc/.sackrc" ]]; then
+  echo "[sack] Creating new rcfile at '$sack__install_sackrc/.sackrc'..."
+  cp "$sack__install_cwd/.sackrc" "$sack__install_sackrc"
+fi


### PR DESCRIPTION
Using a zsh plugin manager such as [zgen](https://github.com/tarjoilija/zgen), installing your ag / ack wrapper becomes a breeze...
No need to manually `git clone` repositories, or configuring it.

It's (in case of zgen) as simple as adding the following line in your `.zshrc`:

```bash
$ cat ~/.zshrc
# load zgen
source "${HOME}/.zgen/zgen.zsh"

# if the init script doesn't exist
if ! zgen saved; then

    # ...

    zgen load sampson-chen/sack
    # or in case of my fork:
    # zgen load UrGuardian4ngel/sack . feature/zsh-plugin-compatibility

    # ...

    zgen save
fi
```

The added line above will automatically:
- clone your repository if it does not exist at startup
  - which will also copy the `.sackrc` file if it does not exist yet
- makes it easy to pull in updates for all plugins (`zgen update`)

And together with tools like [homebrew](https://brew.sh), it's as easy as `brew install the_silver_searcher` to install dependencies like [The Silver Searcher (ag)](https://geoff.greer.fm/ag/).