### PR TITLE
Fix OS detection w/ 'uname' on non-Linux systems

### DIFF
--- a/sack
+++ b/sack
@@ -134,12 +134,14 @@ process_shorcut_paths() {
 # colored output to stdout
 remove_escaped_chars() {
     # Need to do a check for the OS, because Linux uses a different sed
-    # than OS X
+    # than macOS / OS X
+
 
     # Linux / Cygwin
-    if [[ $sack__OS == "Linux" ]] || [[ $sack__OS == "$CYGWIN_NT"* ]]; then
+    # ('sack__OS' is defined in .sackrc)
+    if [[ $sack__OS == "Linux" ]] || [[ $sack__OS == "CYGWIN_NT"* ]]; then
         sed -r "s/\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"
-    # OS X
+    # macOS / OS X
     elif [[ $sack__OS == "Darwin" ]]; then
         sed -E "s/\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"
     fi


### PR DESCRIPTION
Commit ed8a3b6d02974b082d842e384e3541fe6e6abbbd broke OS detection on non-Linux OSes, because `$CYGWIN_NT` expands to nothing when the environment variable `CYGWIN_NT` is undefined.

What @DookTibs _meant_ was just `"$sack__OS == "CYGWIN_NT"*` (no dollar sign). It still _worked_ under Cygwin, but just by luck, because `$sack__OS == *`. Adding `set -u` / `set -o nounset` at the top of the script would stop these kinds of errors from slipping through, but that's a problem for another day.

This PR should fix that problem, and makes OS detection work again on (at least) macOS.